### PR TITLE
Add fieldsAndSimpleModifiers including only the simple name of the field type

### DIFF
--- a/src/main/java/org/netbeans/modules/entityexpander/ExpandEntityAction.java
+++ b/src/main/java/org/netbeans/modules/entityexpander/ExpandEntityAction.java
@@ -190,7 +190,7 @@ public final class ExpandEntityAction extends AbstractAction implements ContextA
                     + "\n"
                     + "public class ${object}Frame extends JFrame {\n"
                     + "    \n"
-                    + "  <#list fieldsAndModifiers as field>\n"
+                    + "  <#list fieldsAndSimpleModifiers as field>\n"
                     + "     ${field};\n"
                     + "  </#list>\n"
                     + "\n"
@@ -264,6 +264,7 @@ public final class ExpandEntityAction extends AbstractAction implements ContextA
                     args.put("fields", fields);
                     args.put("fieldElems", fieldElems);
                     List<String> fieldsAndModifiers = new ArrayList<String>();
+                    List<String> fieldsAndSimpleModifiers = new ArrayList<String>();
                     for (Element e : te.getEnclosedElements()) {
                         if (e.getKind() == ElementKind.FIELD) {
                             Modifier next;
@@ -279,9 +280,18 @@ public final class ExpandEntityAction extends AbstractAction implements ContextA
                                     + " "
                                     + e.getSimpleName().toString()
                             );
+                            String[] tokens = e.asType().toString().split("\\.(?=[^\\.]+$)");
+                            fieldsAndSimpleModifiers.add(
+                                    next
+                                    + " "
+                                    + tokens[tokens.length-1]
+                                    + " "
+                                    + e.getSimpleName().toString()
+                            );
                         }
                     }
                     args.put("fieldsAndModifiers", fieldsAndModifiers);
+                    args.put("fieldsAndSimpleModifiers", fieldsAndSimpleModifiers);
 //                    List<String> methods = new ArrayList<String>();
 //                    for (Element e : te.getEnclosedElements()) {
 //                        if (e.getKind() == ElementKind.METHOD) {

--- a/src/main/resources/org/netbeans/modules/entityexpander/templates/Basic.template
+++ b/src/main/resources/org/netbeans/modules/entityexpander/templates/Basic.template
@@ -7,7 +7,8 @@ comments:
 ${package} fully qualified name of the package
 ${object} the POJO for which the class is created
 ${fields} names of all the fields
-${fieldsAndModifiers} modifier, type, and naame of all the fields
+${fieldsAndModifiers} modifier, type, and name of all the fields
+${fieldsAndSimpleModifiers} modifier, simple name of type, and name of all the fields
 ${fieldElems} field elements
 -->
 package ${package};
@@ -16,7 +17,7 @@ import javax.swing.JPanel;
 
 public class ${object}Panel extends JPanel {
     
-<#list fieldsAndModifiers as field>
+<#list fieldsAndSimpleModifiers as field>
  ${field};
 </#list>
 


### PR DESCRIPTION
To avoid the need to parse the full type name of each field inside the template, I added an additional attribute, fieldsAndSimpleModifiers, with the simple name.
